### PR TITLE
Some android ime fixes.

### DIFF
--- a/src/Avalonia.Base/Input/TextInput/ITextInputMethodClient.cs
+++ b/src/Avalonia.Base/Input/TextInput/ITextInputMethodClient.cs
@@ -29,6 +29,8 @@ namespace Avalonia.Input.TextInput
         /// Sets the non-committed input string
         /// </summary>
         void SetPreeditText(string? text);
+
+        void SetComposingRegion(ComposingRegion? region);
         /// <summary>
         /// Indicates if text input client is capable of providing the text around the cursor
         /// </summary>
@@ -50,5 +52,20 @@ namespace Avalonia.Input.TextInput
         public string Text { get; set; }
         public int CursorOffset { get; set; }
         public int AnchorOffset { get; set; }
+    }
+
+    public readonly struct ComposingRegion
+    {
+        private readonly int _start = -1;
+        private readonly int _end = -1;
+
+        public ComposingRegion(int start, int end)
+        {
+            _start = start;
+            _end = end;
+        }
+
+        public int Start => _start;
+        public int End => _end;
     }
 }

--- a/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
+++ b/src/Avalonia.Controls/TextBoxTextInputMethodClient.cs
@@ -108,6 +108,11 @@ namespace Avalonia.Controls
             }
 
             _presenter.PreeditText = text;
+
+            if(text == null)
+            {
+                _presenter.ComposingRegion = null;
+            }
         }
 
         public void SelectInSurroundingText(int start, int end)
@@ -181,6 +186,16 @@ namespace Avalonia.Controls
                 CursorRectangleChanged?.Invoke(this, e);
 
             }, DispatcherPriority.Input);
+        }
+
+        public void SetComposingRegion(ComposingRegion? region)
+        {
+            if(_presenter == null)
+            {
+                return;
+            }
+
+            _presenter.ComposingRegion = region;
         }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Add composition region to text presenter. Preedit text renders now using the start of composition region. Committing uses SurroundingText.CursorOffset is CompositionRegion is not set.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
